### PR TITLE
chore: remove duplicate package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ eth-ape
 fastapi
 pytest
 uvicorn[standard]
-eth-ape
 vyper
 ape-vyper
 python-multipart


### PR DESCRIPTION
Noticed that we had a duplicate `eth-ape` package in `requirements.txt`.