### PR TITLE
refactor: use manifest project

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,6 +192,7 @@ async def compile_project(project_root: Path, manifest: PackageManifest):
     except Exception as e:
         results[project_root.name] = {e.__class__.__name__: str(e)}
         tasks[project_root.name] = TaskStatus.FAILED
+        return
 
     results[project_root.name] = manifest
     tasks[project_root.name] = TaskStatus.SUCCESS

--- a/main.py
+++ b/main.py
@@ -178,18 +178,10 @@ async def compile_project(project_root: Path, manifest: PackageManifest):
     # Create a contracts directory
     contracts_dir = project_root / "contracts"
     contracts_dir.mkdir()
-    
-    # add request contracts in temp directory
-    if manifest.sources:
-        for filename, source in manifest.sources.items():
-            path = contracts_dir / filename
-            # NOTE: In case there is a multi-level path
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(source.fetch_content())
+    project = Project.from_manifest(manifest)
     try:
-        project = Project(project_root)
-        compiled_manifest = project.extract_manifest()
-        results[project_root.name] = compiled_manifest
+        project.load_contracts()
+        results[project_root.name] = manifest
         tasks[project_root.name] = TaskStatus.SUCCESS
     except CompilerError as e:
         results[project_root.name] = [

--- a/main.py
+++ b/main.py
@@ -192,7 +192,6 @@ async def compile_project(project_root: Path, manifest: PackageManifest):
     except Exception as e:
         results[project_root.name] = {e.__class__.__name__: str(e)}
         tasks[project_root.name] = TaskStatus.FAILED
-        return
-
-    results[project_root.name] = manifest
-    tasks[project_root.name] = TaskStatus.SUCCESS
+    else:
+        results[project_root.name] = manifest
+        tasks[project_root.name] = TaskStatus.SUCCESS

--- a/main.py
+++ b/main.py
@@ -181,6 +181,7 @@ async def compile_project(project_root: Path, manifest: PackageManifest):
     project = Project.from_manifest(manifest)
 
     try:
+        # NOTE: Updates itself because manifest projects are their own cache.
         project.load_contracts()
     except CompilerError as e:
         results[project_root.name] = [


### PR DESCRIPTION
### What I did

This code is a good candidate for Ape's 0.8's manifest-based project

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

run:

```
uvicorn main:app
```

then run

```
ape run client
```

not sure why i cant get tests to run

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
