### PR TITLE
chore: replace deprecated pydantic method

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ app = FastAPI(
 )
 init_openapi(app)
 
-PackageManifest.update_forward_refs()
+PackageManifest.model_rebuild()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],


### PR DESCRIPTION
### What I did

This was causing a deprecation warning to appear because the method was renamed in Pydantic V2

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
