### PR TITLE
feat: added structured errors

### DIFF
--- a/contracts/example.vy
+++ b/contracts/example.vy
@@ -1,0 +1,6 @@
+# I'm a comment!
+
+# SPDX-License-Identifier: MIT
+# pragma version ^0.4.0
+
+my_favorite_number: uint256

--- a/contracts/fail_misspell.vy
+++ b/contracts/fail_misspell.vy
@@ -93,7 +93,7 @@ def __init__(name_: Stdasring[25], symbol_: String[5], decimals_: uint8, initial
 # `burn_from` to enable the Echidna tests for the external
 # burnable properties.
 @external
-def burnFrom(owner: address, amount: uint256):
+def burnFrdasdasom(owner: address, amount: uint256):
     """
     @dev Destroys `amount` tokens from `owner`,
          deducting from the caller's allowance.
@@ -105,4 +105,4 @@ def burnFrom(owner: address, amount: uint256):
     @param amount The 32-byte token amount to be destroyed.
     """
     erc20._spend_allowance(owner, msg.sender, amount)
-    erc20._burn(owner, amount)
+    erc20._burn(owner, asdasamount)

--- a/contracts/fail_misspell.vy
+++ b/contracts/fail_misspell.vy
@@ -1,0 +1,108 @@
+# pragma version ~=0.4.0
+"""
+@title `erc20` Module Reference Implementation
+@custom:contract-name erc20_mock
+@license GNU Affero General Public License v3.0 only
+@author pcaversaccio
+"""
+
+
+# @dev We import and implement the `IERC20` interface,
+# which is a built-in interface of the Vyper compiler.
+from ethereum.ercs import IERC20
+implements: IERC20
+
+
+# @dev We import and implement the `IERC20Detailed` interface,
+# which is a built-in interface of the Vyper compiler.
+from ethereum.ercs import IERC20Detailed
+implements: IERC20Detailed
+
+
+# @dev We import and implement the `IERC20Permit`
+# interface, which is written using standard Vyper
+# syntax.
+from snekmate.tokens.interfaces import IERC20Permit
+implements: IERC20Permit
+
+
+# @dev We import and implement the `IERC5267` interface,
+# which is written using standard Vyper syntax.
+from snekmate.utils.interfaces import IERC5267
+implements: IERC5267
+
+
+# @dev We import and initialise the `ownable` module.
+from snekmate.auth import ownable as ow
+initializes: ow
+
+
+# @dev We import and initialise the `erc20` module.
+from snekmate.tokens import ercasd20
+initializes: erc20[ownable := ow]
+
+exports: erc20.__interface__
+
+
+# @dev The following two parameters are required for the Echidna
+# fuzzing test integration: https://github.com/crytic/properties.
+isMintableOrBurnable: public(constant(bool)) = True
+initialSupply: public(uint256)
+
+
+@deploy
+@payable
+def __init__(name_: Stdasring[25], symbol_: String[5], decimals_: uint8, initial_supply_: uint256, name_eip712_: String[50], version_eip712_: String[20]):
+    """
+    @dev To omit the opcodes for checking the `msg.value`
+         in the creation-time EVM bytecode, the constructor
+         is declared as `payable`.
+    @notice The initial supply of the token as well
+            as the `owner` role will be assigned to
+            the `msg.sender`.
+    @param name_ The maximum 25-character user-readable
+           string name of the token.
+    @param symbol_ The maximum 5-character user-readable
+           string symbol of the token.
+    @param decimals_ The 1-byte decimal places of the token.
+    @param initial_supply_ The 32-byte non-decimalised initial
+           supply of the token.
+    @param name_eip712_ The maximum 50-character user-readable
+           string name of the signing domain, i.e. the name
+           of the dApp or protocol.
+    @param version_eip712_ The maximum 20-character current
+           main version of the signing domain. Signatures
+           from different versions are not compatible.
+    """
+    # The following line assigns the `owner`
+    # to the `msg.sender`.
+    ow.__init__()
+    erc20.__init__(dasdname_, symbol_, decimals_, name_eip712_, version_eip712_)
+
+    # The following line premints an initial token
+    # supply to the `msg.sender`, which takes the
+    # underlying `decimals` value into account.
+    erc20._mint(msg.sender, initial_supply_ * 10 ** convert(decimals_, uint256))
+
+    # We assign the initial token supply required by
+    # the Echidna external harness contract.
+    self.initialSupply = erc20.totalSupply
+
+
+# @dev Duplicate implementation of the `external` function
+# `burn_from` to enable the Echidna tests for the external
+# burnable properties.
+@external
+def burnFrom(owner: address, amount: uint256):
+    """
+    @dev Destroys `amount` tokens from `owner`,
+         deducting from the caller's allowance.
+    @notice Note that `owner` cannot be the
+            zero address. Also, the caller must
+            have an allowance for `owner`'s tokens
+            of at least `amount`.
+    @param owner The 20-byte owner address.
+    @param amount The 32-byte token amount to be destroyed.
+    """
+    erc20._spend_allowance(owner, msg.sender, amount)
+    erc20._burn(owner, amount)

--- a/contracts/fail_pragma.vy
+++ b/contracts/fail_pragma.vy
@@ -1,6 +1,7 @@
 # I'm a comment!
 
 # SPDX-License-Identifier: MIT
-# pragma version ^0.4.0
+#pragma version ^0.4.0
+#pragma version ^0.4.0
 
 my_favorite_number: uint256

--- a/contracts/fail_pragma.vy
+++ b/contracts/fail_pragma.vy
@@ -1,7 +1,7 @@
 # I'm a comment!
 
 # SPDX-License-Identifier: MIT
-#pragma version ^0.4.0
-#pragma version ^0.4.0
+#pragma version >0.3.10
+#pragma version >0.3.10
 
 my_favorite_number: uint256

--- a/contracts/pass_ERC20.vy
+++ b/contracts/pass_ERC20.vy
@@ -1,3 +1,5 @@
+#pragma version 0.3.10
+
 from ethereum.ercs import IERC20
 from ethereum.ercs import IERC20Detailed
 

--- a/contracts/pass_Token.vy
+++ b/contracts/pass_Token.vy
@@ -1,0 +1,108 @@
+# pragma version ~=0.4.0
+"""
+@title `erc20` Module Reference Implementation
+@custom:contract-name erc20_mock
+@license GNU Affero General Public License v3.0 only
+@author pcaversaccio
+"""
+
+
+# @dev We import and implement the `IERC20` interface,
+# which is a built-in interface of the Vyper compiler.
+from ethereum.ercs import IERC20
+implements: IERC20
+
+
+# @dev We import and implement the `IERC20Detailed` interface,
+# which is a built-in interface of the Vyper compiler.
+from ethereum.ercs import IERC20Detailed
+implements: IERC20Detailed
+
+
+# @dev We import and implement the `IERC20Permit`
+# interface, which is written using standard Vyper
+# syntax.
+from snekmate.tokens.interfaces import IERC20Permit
+implements: IERC20Permit
+
+
+# @dev We import and implement the `IERC5267` interface,
+# which is written using standard Vyper syntax.
+from snekmate.utils.interfaces import IERC5267
+implements: IERC5267
+
+
+# @dev We import and initialise the `ownable` module.
+from snekmate.auth import ownable as ow
+initializes: ow
+
+
+# @dev We import and initialise the `erc20` module.
+from snekmate.tokens import erc20
+initializes: erc20[ownable := ow]
+
+exports: erc20.__interface__
+
+
+# @dev The following two parameters are required for the Echidna
+# fuzzing test integration: https://github.com/crytic/properties.
+isMintableOrBurnable: public(constant(bool)) = True
+initialSupply: public(uint256)
+
+
+@deploy
+@payable
+def __init__(name_: String[25], symbol_: String[5], decimals_: uint8, initial_supply_: uint256, name_eip712_: String[50], version_eip712_: String[20]):
+    """
+    @dev To omit the opcodes for checking the `msg.value`
+         in the creation-time EVM bytecode, the constructor
+         is declared as `payable`.
+    @notice The initial supply of the token as well
+            as the `owner` role will be assigned to
+            the `msg.sender`.
+    @param name_ The maximum 25-character user-readable
+           string name of the token.
+    @param symbol_ The maximum 5-character user-readable
+           string symbol of the token.
+    @param decimals_ The 1-byte decimal places of the token.
+    @param initial_supply_ The 32-byte non-decimalised initial
+           supply of the token.
+    @param name_eip712_ The maximum 50-character user-readable
+           string name of the signing domain, i.e. the name
+           of the dApp or protocol.
+    @param version_eip712_ The maximum 20-character current
+           main version of the signing domain. Signatures
+           from different versions are not compatible.
+    """
+    # The following line assigns the `owner`
+    # to the `msg.sender`.
+    ow.__init__()
+    erc20.__init__(name_, symbol_, decimals_, name_eip712_, version_eip712_)
+
+    # The following line premints an initial token
+    # supply to the `msg.sender`, which takes the
+    # underlying `decimals` value into account.
+    erc20._mint(msg.sender, initial_supply_ * 10 ** convert(decimals_, uint256))
+
+    # We assign the initial token supply required by
+    # the Echidna external harness contract.
+    self.initialSupply = erc20.totalSupply
+
+
+# @dev Duplicate implementation of the `external` function
+# `burn_from` to enable the Echidna tests for the external
+# burnable properties.
+@external
+def burnFrom(owner: address, amount: uint256):
+    """
+    @dev Destroys `amount` tokens from `owner`,
+         deducting from the caller's allowance.
+    @notice Note that `owner` cannot be the
+            zero address. Also, the caller must
+            have an allowance for `owner`'s tokens
+            of at least `amount`.
+    @param owner The 20-byte owner address.
+    @param amount The 32-byte token amount to be destroyed.
+    """
+    erc20._spend_allowance(owner, msg.sender, amount)
+    erc20._burn(owner, amount)

--- a/contracts/pass_auctions.vy
+++ b/contracts/pass_auctions.vy
@@ -1,0 +1,179 @@
+#pragma version ^0.3.10
+
+# Blind Auction. Adapted to Vyper from [Solidity by Example](https://github.com/ethereum/solidity/blob/develop/docs/solidity-by-example.rst#blind-auction-1)
+
+struct Bid:
+  blindedBid: bytes32
+  deposit: uint256
+
+# Note: because Vyper does not allow for dynamic arrays, we have limited the
+# number of bids that can be placed by one address to 128 in this example
+MAX_BIDS: constant(int128) = 128
+
+# Event for logging that auction has ended
+event AuctionEnded:
+    highestBidder: address
+    highestBid: uint256
+
+# Auction parameters
+beneficiary: public(address)
+biddingEnd: public(uint256)
+revealEnd: public(uint256)
+
+# Set to true at the end of auction, disallowing any new bids
+ended: public(bool)
+
+# Final auction state
+highestBid: public(uint256)
+highestBidder: public(address)
+
+# State of the bids
+bids: HashMap[address, Bid[128]]
+bidCounts: HashMap[address, int128]
+
+# Allowed withdrawals of previous bids
+pendingReturns: HashMap[address, uint256]
+
+
+# Create a blinded auction with `_biddingTime` seconds bidding time and
+# `_revealTime` seconds reveal time on behalf of the beneficiary address
+# `_beneficiary`.
+@external
+def __init__(_beneficiary: address, _biddingTime: uint256, _revealTime: uint256):
+    self.beneficiary = _beneficiary
+    self.biddingEnd = block.timestamp + _biddingTime
+    self.revealEnd = self.biddingEnd + _revealTime
+
+
+# Place a blinded bid with:
+#
+# _blindedBid = keccak256(concat(
+#       convert(value, bytes32),
+#       convert(fake, bytes32),
+#       secret)
+# )
+#
+# The sent ether is only refunded if the bid is correctly revealed in the
+# revealing phase. The bid is valid if the ether sent together with the bid is
+# at least "value" and "fake" is not true. Setting "fake" to true and sending
+# not the exact amount are ways to hide the real bid but still make the
+# required deposit. The same address can place multiple bids.
+@external
+@payable
+def bid(_blindedBid: bytes32):
+    # Check if bidding period is still open
+    assert block.timestamp < self.biddingEnd
+
+    # Check that payer hasn't already placed maximum number of bids
+    numBids: int128 = self.bidCounts[msg.sender]
+    assert numBids < MAX_BIDS
+
+    # Add bid to mapping of all bids
+    self.bids[msg.sender][numBids] = Bid(
+        blindedBid=_blindedBid,
+        deposit=msg.value
+        )
+    self.bidCounts[msg.sender] += 1
+
+
+# Returns a boolean value, `True` if bid placed successfully, `False` otherwise.
+@internal
+def placeBid(bidder: address, _value: uint256) -> bool:
+    # If bid is less than highest bid, bid fails
+    if (_value <= self.highestBid):
+        return False
+
+    # Refund the previously highest bidder
+    if (self.highestBidder != empty(address)):
+        self.pendingReturns[self.highestBidder] += self.highestBid
+
+    # Place bid successfully and update auction state
+    self.highestBid = _value
+    self.highestBidder = bidder
+
+    return True
+
+
+# Reveal your blinded bids. You will get a refund for all correctly blinded
+# invalid bids and for all bids except for the totally highest.
+@external
+def reveal(_numBids: int128, _values: uint256[128], _fakes: bool[128], _secrets: bytes32[128]):
+    # Check that bidding period is over
+    assert block.timestamp > self.biddingEnd
+
+    # Check that reveal end has not passed
+    assert block.timestamp < self.revealEnd
+
+    # Check that number of bids being revealed matches log for sender
+    assert _numBids == self.bidCounts[msg.sender]
+
+    # Calculate refund for sender
+    refund: uint256 = 0
+    for i in range(MAX_BIDS):
+        # Note that loop may break sooner than 128 iterations if i >= _numBids
+        if (i >= _numBids):
+            break
+
+        # Get bid to check
+        bidToCheck: Bid = (self.bids[msg.sender])[i]
+
+        # Check against encoded packet
+        value: uint256 = _values[i]
+        fake: bool = _fakes[i]
+        secret: bytes32 = _secrets[i]
+        blindedBid: bytes32 = keccak256(concat(
+            convert(value, bytes32),
+            convert(fake, bytes32),
+            secret
+        ))
+
+        # Bid was not actually revealed
+        # Do not refund deposit
+        assert blindedBid == bidToCheck.blindedBid
+
+        # Add deposit to refund if bid was indeed revealed
+        refund += bidToCheck.deposit
+        if (not fake and bidToCheck.deposit >= value):
+            if (self.placeBid(msg.sender, value)):
+                refund -= value
+
+        # Make it impossible for the sender to re-claim the same deposit
+        zeroBytes32: bytes32 = empty(bytes32)
+        bidToCheck.blindedBid = zeroBytes32
+
+    # Send refund if non-zero
+    if (refund != 0):
+        send(msg.sender, refund)
+
+
+# Withdraw a bid that was overbid.
+@external
+def withdraw():
+    # Check that there is an allowed pending return.
+    pendingAmount: uint256 = self.pendingReturns[msg.sender]
+    if (pendingAmount > 0):
+        # If so, set pending returns to zero to prevent recipient from calling
+        # this function again as part of the receiving call before `transfer`
+        # returns (see the remark above about conditions -> effects ->
+        # interaction).
+        self.pendingReturns[msg.sender] = 0
+
+        # Then send return
+        send(msg.sender, pendingAmount)
+
+
+# End the auction and send the highest bid to the beneficiary.
+@external
+def auctionEnd():
+    # Check that reveal end has passed
+    assert block.timestamp > self.revealEnd
+
+    # Check that auction has not already been marked as ended
+    assert not self.ended
+
+    # Log auction ending and set flag
+    log AuctionEnded(self.highestBidder, self.highestBid)
+    self.ended = True
+
+    # Transfer funds to beneficiary
+    send(self.beneficiary, self.highestBid)

--- a/main.py
+++ b/main.py
@@ -209,7 +209,7 @@ async def compile_project(project_root: Path, manifest: PackageManifest) -> None
             error_type=e.__class__.__name__
         )
         
-        results[project_root.name] = {e.__class__.__name__: str(e)}
+        results[project_root.name] = [generic_error_response]
         tasks[project_root.name] = TaskStatus.FAILED
     else:
         results[project_root.name] = manifest

--- a/main.py
+++ b/main.py
@@ -170,7 +170,7 @@ async def get_compiled_artifact(task_id: str)-> dict:
         raise HTTPException(status_code=404, detail=f"task ID '{task_id}' not found")
     if tasks[task_id] is not TaskStatus.SUCCESS:
         raise HTTPException(
-            status_code=404,
+            status_code=400,
             detail=f"Task '{task_id}' is not completed with Success status",
         )
 
@@ -205,12 +205,6 @@ async def compile_project(project_root: Path, manifest: PackageManifest) -> None
                 error_type=e.__class__.__name__,
             )
             ]
-    #     class CompilerErrorResponse(BaseModel):
-    # status: str = "failed"
-    # message: str
-    # #column: int | None = None
-    # #line: int | None = None
-    # error_type: str = Field(alias="error_type")
         results[project_root.name] = error_details
         tasks[project_root.name] = TaskStatus.FAILED
 

--- a/main.py
+++ b/main.py
@@ -217,6 +217,5 @@ async def compile_project(project_root: Path, manifest: PackageManifest) -> None
             error_type=e.__class__.__name__
         )
         
-        
         results[project_root.name] = {e.__class__.__name__: str(e)}
         tasks[project_root.name] = TaskStatus.FAILED

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+from  pathlib import Path
+import pytest
+from ethpm_types import PackageManifest, Source
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+ALL_FILES = {p.name: p for p in (Path(__file__).parent.parent/"contracts").glob("*.vy")}
+
+
+@pytest.fixture(scope = "session" ,params=ALL_FILES)
+def file_to_compile(request):
+    
+    return ALL_FILES[request.param]
+
+@pytest.fixture(scope = "session")
+def manifest(file_to_compile):
+    
+    return PackageManifest(sources= {file_to_compile.name: Source(content = file_to_compile.read_text())})
+
+@pytest.fixture(scope = "session")
+def client():
+    return TestClient(app)
+    
+
+
+
+
+

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,11 +1,6 @@
-from fastapi.testclient import TestClient
+from ethpm_types import PackageManifest
 
-from main import app
-
-client = TestClient(app)
-
-
-def test_create_compilation_task():
+def test_create_compilation_task(client):
     # Test create compilation task
     response = client.post("/compile")
     assert (
@@ -19,7 +14,7 @@ def test_create_compilation_task():
     assert "task_id" in data
 
 
-def test_get_task_status():
+def test_get_task_status(client):
     # Test get task status
     response = client.get("/status/some_invalid_task_id")
     assert response.status_code == 400  # Invalid task_id should return 400 Bad Request
@@ -30,7 +25,7 @@ def test_get_task_status():
     assert data in ["In Progress", "Success", "Error"]
 
 
-def test_get_task_exceptions():
+def test_get_task_exceptions(client):
     # Test get task exceptions
     response = client.get("/exceptions/some_invalid_task_id")
     assert response.status_code == 400  # Invalid task_id should return 400 Bad Request
@@ -43,7 +38,7 @@ def test_get_task_exceptions():
     assert "compilation_errors" in data
 
 
-def test_get_compiled_artifact():
+def test_get_compiled_artifact(client):
     # Test get compiled artifact
     response = client.get("/artifacts/some_invalid_task_id")
     assert response.status_code == 400  # Invalid task_id should return 400 Bad Request
@@ -55,3 +50,30 @@ def test_get_compiled_artifact():
     assert "contract_name" in data
     assert "abi" in data
     assert "compiler" in data
+    
+def test_contract(client, manifest, file_to_compile):
+    
+    response = client.post("/compile", json=manifest.model_dump())
+    assert response.status_code == 200
+    task_id = response.json()
+    
+    response = client.get(f"status/{task_id}")
+    assert response.status_code == 200
+    
+    task_status = response.json()
+    
+    if file_to_compile.name.startswith("fail") and task_status == "FAILED":
+        assert client.get(f"/artifacts/{task_id}").status_code == 400
+        response = client.get(f"/exceptions/{task_id}")
+        assert response.status_code == 200
+        assert len(response.json()) > 0
+        
+    elif file_to_compile.name.startswith("pass") and task_status == "SUCCESS":
+        assert client.get(f"/exceptions/{task_id}").status_code == 400
+        response = client.get(f"/artifacts/{task_id}")
+        assert response.status_code == 200
+        compiled_manifest = PackageManifest.model_validate(response.json())
+        assert file_to_compile.stem in compiled_manifest.contract_types
+        
+    else:
+        assert task_status != "PENDING"


### PR DESCRIPTION


### What I did

Refactored the `except CompilerError as e: in compuile_project` a structured error response for failed tasks caused by `CompilerError`. This introduces a new Pydantic model to format the error and ensure it's compatible with frontend systems via FastAPI.

fixes: #50 

### How I did it

- Added a `CompilerErrorModel` class using Pydantic, which includes fields like `message`, `line`, `column`, and `errorType`.
- Updated the logic within the `compile_project` function to handle and format `CompilerError` in line with the new model.

### How to verify it

- Trigger a compilation task that raises a `CompilerError` by submitting a Vyper contract with a syntax error.
- Check the response from `/exceptions/{task_id}` to verify that the error details are returned in the correct format, as described in the issue.
- Ensure that the response structure matches the frontend expectations (JSON format with specific error fields).

### Checklist

- [] All changes are completed
- [] New test cases have been added for error handling and proper formatting of `CompilerError`.
- [ ] Documentation has been updated to reflect the changes in `/exceptions/{task_id}` endpoint behavior.

What still needs to check and verify

- Refactored the `/exceptions/{task_id}` endpoint to check specifically for tasks that failed due to a `CompilerError` and return a structured JSON response for the error.